### PR TITLE
US-18983 Исправления багов в плагине Wordpress

### DIFF
--- a/assets/css/unisender.css
+++ b/assets/css/unisender.css
@@ -130,6 +130,7 @@
     line-height: inherit;
     outline: none;
     margin: 0;
+    box-sizing: border-box;
 }
 
 .b-unisender-form .b-unisender-field__error-text {

--- a/includes/controller.php
+++ b/includes/controller.php
@@ -11,7 +11,9 @@ function wpunisender_action_callback()
     }
     $api = new \Unisender\ApiWrapper\UnisenderApi($api_key);
 
-    $formData = json_decode(str_replace('\"', '"', $_POST['data']), true);
+    $data = str_replace(['\"','\\\"'], ['"', '\"'], $_POST['data']);
+    $formData = json_decode($data, true);
+
     $double_optin = 3;
     if (empty($formData)) {
         wpunisender_subscribe_send_error_response([


### PR DESCRIPTION
1) Пользователь не может в текстовом поле не может использовать специальные знаки, например, двойные кавычки. Нужно предусмотреть возможность передачи текстовых данных с использованием специальных знаков.
2) Некорректное отображение формы подписки - поправить верстку